### PR TITLE
MULE-13034: Error responses with special characters should be scaped.

### DIFF
--- a/services-all/pom.xml
+++ b/services-all/pom.xml
@@ -88,6 +88,10 @@
                     <groupId>org.glassfish.grizzly</groupId>
                     <artifactId>grizzly-websockets</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-text</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
Adding commons-text exclussion.