### PR TITLE
MULE-13968: Replace log4j-jul and log4j-jcl with jul-to-slf4j and

### DIFF
--- a/standalone/assembly-whitelist.txt
+++ b/standalone/assembly-whitelist.txt
@@ -72,12 +72,11 @@
 /mule-standalone-${productVersion}/lib/boot/wrapper-windows-x86-32.dll
 /mule-standalone-${productVersion}/lib/boot/disruptor-3.3.0.jar
 /mule-standalone-${productVersion}/lib/boot/jcl-over-slf4j-1.7.25.jar
+/mule-standalone-${productVersion}/lib/boot/jul-to-slf4j-1.7.25.jar
 /mule-standalone-${productVersion}/lib/boot/log4j-1.2-api-2.8.2.jar
 /mule-standalone-${productVersion}/lib/boot/log4j-api-2.8.2.jar
 /mule-standalone-${productVersion}/lib/boot/log4j-core-2.8.2.jar
-/mule-standalone-${productVersion}/lib/boot/log4j-jcl-2.8.2.jar
 /mule-standalone-${productVersion}/lib/boot/log4j-slf4j-impl-2.8.2.jar
-/mule-standalone-${productVersion}/lib/boot/log4j-jul-2.8.2.jar
 /mule-standalone-${productVersion}/lib/boot/slf4j-api-1.7.25.jar
 
 #

--- a/standalone/assembly.xml
+++ b/standalone/assembly.xml
@@ -111,9 +111,8 @@
                 <include>org.apache.logging.log4j:log4j-core</include>
                 <include>org.apache.logging.log4j:log4j-slf4j-impl</include>
                 <include>org.apache.logging.log4j:log4j-1.2-api</include>
-                <include>org.apache.logging.log4j:log4j-jcl</include>
-                <include>org.apache.logging.log4j:log4j-jul</include>
                 <include>org.slf4j:jcl-over-slf4j</include>
+                <include>org.slf4j:jul-to-slf4j</include>
                 <include>com.lmax:disruptor</include>
             </includes>
         </dependencySet>
@@ -268,9 +267,8 @@
                 <exclude>org.apache.logging.log4j:log4j-core</exclude>
                 <exclude>org.apache.logging.log4j:log4j-slf4j-impl</exclude>
                 <exclude>org.apache.logging.log4j:log4j-1.2-api</exclude>
-                <exclude>org.apache.logging.log4j:log4j-jcl</exclude>
-                <exclude>org.apache.logging.log4j:log4j-jul</exclude>
                 <exclude>org.slf4j:jcl-over-slf4j</exclude>
+                <exclude>org.slf4j:jul-to-slf4j</exclude>
                 <exclude>commons-logging:commons-logging</exclude>
                 <exclude>com.lmax:disruptor</exclude>
 

--- a/standalone/src/main/resources/bin/mule
+++ b/standalone/src/main/resources/bin/mule
@@ -99,9 +99,6 @@ APP_LONG_NAME=${MULE_APP_LONG}
 WRAPPER_CMD="${MULE_HOME}/lib/boot/exec/wrapper"
 WRAPPER_CONF="${MULE_BASE}/conf/wrapper.conf"
 
-# redirect JUL logs to log4j2
-JUL_LOG_MANAGER=-M-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
-
 MULE_OPTS="wrapper.working.dir=\"$STARTUP_DIR\" \
            wrapper.app.parameter.1=$2 \
            wrapper.app.parameter.2=$3 \
@@ -621,7 +618,7 @@ dump() {
 
 checkAdditionalJvmParams() {
     # The string passed to eval must handle spaces in paths correctly.
-    "$MULE_HOME/bin/launcher" \"$MULE_HOME/bin/additional.groovy\" \"$WRAPPER_CONF\" \"$JPDA_OPTS\" \"$JUL_LOG_MANAGER\" $@
+    "$MULE_HOME/bin/launcher" \"$MULE_HOME/bin/additional.groovy\" \"$WRAPPER_CONF\" \"$JPDA_OPTS\" $@
     EXIT_STATUS=$?
 
     if [ "$EXIT_STATUS" -ne "0" ] ; then        

--- a/standalone/src/main/resources/bin/mule.bat
+++ b/standalone/src/main/resources/bin/mule.bat
@@ -88,15 +88,12 @@ rem ###############################################################
 rem Customized for Mule
 rem ###############################################################
 
-rem redirect JUL logs to log4j2
-set JUL_LOG_MANAGER=-M-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
-
 rem Mule options: Set the working directory to the current one and pass all command-line
 rem options (-config, -builder, etc.) straight through to the main() method.
 set MULE_OPTS=set.MULE_APP=%MULE_APP% set.MULE_APP_LONG=%MULE_APP_LONG% set.MULE_HOME="%MULE_HOME%" set.MULE_BASE="%MULE_BASE%" set.MULE_LIB=%MULE_LIB% wrapper.working.dir="%CD%" wrapper.app.parameter.1=%1 wrapper.app.parameter.2=%2  wrapper.app.parameter.3=%3  wrapper.app.parameter.4=%4  wrapper.app.parameter.5=%5  wrapper.app.parameter.6=%6  wrapper.app.parameter.7=%7  wrapper.app.parameter.8=%8 wrapper.app.parameter.9=%9
 
 rem Adding additional jvm arguments to wrapper configuration if needed
-call "%MULE_HOME%\bin\launcher.bat" "%MULE_HOME%\bin\additional.groovy" %_WRAPPER_CONF% "%JPDA_OPTS%" "%JUL_LOG_MANAGER%" %*
+call "%MULE_HOME%\bin\launcher.bat" "%MULE_HOME%\bin\additional.groovy" %_WRAPPER_CONF% "%JPDA_OPTS%" %*
 
 if not ERRORLEVEL 1 goto run
 goto :eof


### PR DESCRIPTION
jcl-over-slf4j

Checking if a log level is enabled using the JUL api has different
processing times depending on the bridge used.
Benchmarking showed that jul-to-slf4j outperforms log4j-jul in a 1:10
ratio. Since this check using the jul api is used heavily by grizzly,
making this change should improve the performance of the http service.

Also, change the bridge of JCL for consistency. Benchmarking didn't show
any degradation