### PR TITLE
MULE-14070: Upgrade log4j to 2.9.1

### DIFF
--- a/standalone/assembly-whitelist.txt
+++ b/standalone/assembly-whitelist.txt
@@ -54,13 +54,13 @@
 /mule-standalone-${productVersion}/lib/boot/README.txt
 /mule-standalone-${productVersion}/lib/boot/wrapper-3.2.3.jar
 /mule-standalone-${productVersion}/lib/boot/wrapper-windows-x86-32.dll
-/mule-standalone-${productVersion}/lib/boot/disruptor-3.3.0.jar
+/mule-standalone-${productVersion}/lib/boot/disruptor-3.3.7.jar
 /mule-standalone-${productVersion}/lib/boot/jcl-over-slf4j-1.7.25.jar
 /mule-standalone-${productVersion}/lib/boot/jul-to-slf4j-1.7.25.jar
-/mule-standalone-${productVersion}/lib/boot/log4j-1.2-api-2.8.2.jar
-/mule-standalone-${productVersion}/lib/boot/log4j-api-2.8.2.jar
-/mule-standalone-${productVersion}/lib/boot/log4j-core-2.8.2.jar
-/mule-standalone-${productVersion}/lib/boot/log4j-slf4j-impl-2.8.2.jar
+/mule-standalone-${productVersion}/lib/boot/log4j-1.2-api-2.10.0.jar
+/mule-standalone-${productVersion}/lib/boot/log4j-api-2.10.0.jar
+/mule-standalone-${productVersion}/lib/boot/log4j-core-2.10.0.jar
+/mule-standalone-${productVersion}/lib/boot/log4j-slf4j-impl-2.10.0.jar
 /mule-standalone-${productVersion}/lib/boot/slf4j-api-1.7.25.jar
 
 #


### PR DESCRIPTION
_ Upgrading log4j to 2.10.0
_ Upgrading disruptor to 3.3.7
_ Fixing test runner issue with context classloader