### PR TITLE
Fix assembly configuration to avoid 'group id ... is too big' on Mac …

### DIFF
--- a/standalone/pom.xml
+++ b/standalone/pom.xml
@@ -71,7 +71,7 @@
                         <descriptor>assembly.xml</descriptor>
                     </descriptors>
                     <appendAssemblyId>false</appendAssemblyId>
-                    <tarLongFileMode>gnu</tarLongFileMode>
+                    <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
…environments