### PR TITLE
MULE-16042: javax packages not being resolved properly on JDK11

### DIFF
--- a/standalone/assembly-whitelist.txt
+++ b/standalone/assembly-whitelist.txt
@@ -187,7 +187,7 @@
 /mule-standalone-${productVersion}/lib/opt/javax.json-1.0.4.jar
 /mule-standalone-${productVersion}/lib/opt/javax.json-api-1.0.jar
 /mule-standalone-${productVersion}/lib/opt/javax.jws-api-1.1.jar
-/mule-standalone-${productVersion}/lib/opt/javax.transaction-api-1.2.jar
+/mule-standalone-${productVersion}/lib/opt/javax.transaction-api-1.3.jar
 /mule-standalone-${productVersion}/lib/opt/javax.xml.soap-api-1.4.0.jar
 /mule-standalone-${productVersion}/lib/opt/jaxws-api-2.3.0.jar
 /mule-standalone-${productVersion}/lib/opt/jaxb-runtime-2.3.0-MULE-001.jar
@@ -197,7 +197,6 @@
 /mule-standalone-${productVersion}/lib/opt/jaxb-core-2.3.0-MULE-001.jar
 /mule-standalone-${productVersion}/lib/opt/stax-ex-1.7.8.jar
 /mule-standalone-${productVersion}/lib/opt/txw2-2.3.0-MULE-001.jar
-/mule-standalone-${productVersion}/lib/opt/jaxen-1.1.1.jar
 /mule-standalone-${productVersion}/lib/opt/jcommander-1.69.jar
 /mule-standalone-${productVersion}/lib/opt/jgrapht-jdk1.5-0.7.3.jar
 /mule-standalone-${productVersion}/lib/opt/joda-time-2.9.1.jar


### PR DESCRIPTION
* Upgrade transactions-api to 1.3
* Remove jaxen dependency