### PR TITLE
MULE-15969: Upgrade cglib to latest version

### DIFF
--- a/standalone/assembly-whitelist.txt
+++ b/standalone/assembly-whitelist.txt
@@ -155,7 +155,7 @@
 /mule-standalone-${productVersion}/lib/opt/aspectjweaver-1.9.2.jar
 /mule-standalone-${productVersion}/lib/opt/btf-1.2.jar
 /mule-standalone-${productVersion}/lib/opt/caffeine-2.6.2.jar
-/mule-standalone-${productVersion}/lib/opt/cglib-nodep-3.2.6.jar
+/mule-standalone-${productVersion}/lib/opt/cglib-nodep-3.2.10.jar
 /mule-standalone-${productVersion}/lib/opt/checker-qual-2.0.0.jar
 /mule-standalone-${productVersion}/lib/opt/commons-beanutils-1.9.3.jar
 /mule-standalone-${productVersion}/lib/opt/commons-codec-1.11.jar


### PR DESCRIPTION
- Updating cglib to the latest version `3.2.10` which already supports ASM 7