### PR TITLE
MULE-16417: Fix issues affecting mule-aggregators-module tests on Java 11

### DIFF
--- a/standalone/assembly-whitelist.txt
+++ b/standalone/assembly-whitelist.txt
@@ -189,11 +189,13 @@
 /mule-standalone-${productVersion}/lib/opt/javax.jws-api-1.1.jar
 /mule-standalone-${productVersion}/lib/opt/javax.transaction-api-1.3.jar
 /mule-standalone-${productVersion}/lib/opt/javax.xml.soap-api-1.4.0.jar
-/mule-standalone-${productVersion}/lib/opt/jaxws-api-2.3.0.jar
+/mule-standalone-${productVersion}/lib/opt/jaxws-api-2.3.1.jar
 /mule-standalone-${productVersion}/lib/opt/jaxb-runtime-2.3.1-MULE-001.jar
 /mule-standalone-${productVersion}/lib/opt/FastInfoset-1.2.15.jar
 /mule-standalone-${productVersion}/lib/opt/istack-commons-runtime-3.0.7.jar
 /mule-standalone-${productVersion}/lib/opt/jaxb-api-2.3.1.jar
+/mule-standalone-${productVersion}/lib/opt/jaxb-core-2.3.0.1.jar
+/mule-standalone-${productVersion}/lib/opt/jaxb-impl-2.3.1.jar
 /mule-standalone-${productVersion}/lib/opt/stax-ex-1.8.jar
 /mule-standalone-${productVersion}/lib/opt/txw2-2.3.1-MULE-001.jar
 /mule-standalone-${productVersion}/lib/opt/jcommander-1.69.jar


### PR DESCRIPTION
- Updating whitelist after the changes on `mule-module-javaee` for
 fixing test issues with Java 11 after the "JEP 320: Remove the Java EE
 and CORBA Modules"