### PR TITLE
MULE-18383: Log4j upgrade on mule runtime 4.1.5, from log4j 2.11.0 to

### DIFF
--- a/standalone/assembly-whitelist.txt
+++ b/standalone/assembly-whitelist.txt
@@ -58,10 +58,10 @@
 /mule-standalone-${productVersion}/lib/boot/disruptor-3.3.7.jar
 /mule-standalone-${productVersion}/lib/boot/jcl-over-slf4j-1.7.26.jar
 /mule-standalone-${productVersion}/lib/boot/jul-to-slf4j-1.7.26.jar
-/mule-standalone-${productVersion}/lib/boot/log4j-1.2-api-2.11.0.jar
-/mule-standalone-${productVersion}/lib/boot/log4j-api-2.11.0.jar
-/mule-standalone-${productVersion}/lib/boot/log4j-core-2.11.0.jar
-/mule-standalone-${productVersion}/lib/boot/log4j-slf4j-impl-2.11.0.jar
+/mule-standalone-${productVersion}/lib/boot/log4j-1.2-api-2.11.2.jar
+/mule-standalone-${productVersion}/lib/boot/log4j-api-2.11.2.jar
+/mule-standalone-${productVersion}/lib/boot/log4j-core-2.11.2.jar
+/mule-standalone-${productVersion}/lib/boot/log4j-slf4j-impl-2.11.2.jar
 /mule-standalone-${productVersion}/lib/boot/slf4j-api-1.7.26.jar
 /mule-standalone-${productVersion}/lib/boot/jackson-annotations-2.10.0.jar
 /mule-standalone-${productVersion}/lib/boot/jackson-core-2.10.0.jar


### PR DESCRIPTION
2.11.2