### PR TITLE
DEL-149: Cherry-pick fixes of mule-distributions and mule-ee-distributions for Munit patches in new support patches of the released versions

### DIFF
--- a/bom/runtime-impl/pom.xml
+++ b/bom/runtime-impl/pom.xml
@@ -19,6 +19,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.mule.patches</groupId>
+            <artifactId>MULE-15441-4.1.2</artifactId>
+            <version>1.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-core</artifactId>
             <version>${mule.version}</version>

--- a/bom/runtime-impl/pom.xml
+++ b/bom/runtime-impl/pom.xml
@@ -20,9 +20,10 @@
     <dependencies>
         <dependency>
             <groupId>org.mule.patches</groupId>
-            <artifactId>MULE-15441-4.1.2</artifactId>
-            <version>1.1</version>
+            <artifactId>SE-9843-4.1.3</artifactId>
+            <version>1.0</version>
         </dependency>
+
         <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-core</artifactId>


### PR DESCRIPTION
- Bringing patches from `hfx-munit` branch to its support counterpart