### PR TITLE
DEL-149: Cherry-pick fixes of mule-distributions and mule-ee-distributions for Munit patches in new support patches of the released versions

### DIFF
--- a/bom/runtime-impl/pom.xml
+++ b/bom/runtime-impl/pom.xml
@@ -20,6 +20,12 @@
     <dependencies>
         <dependency>
             <groupId>org.mule.patches</groupId>
+            <artifactId>SE-10300-4.1.4</artifactId>
+            <version>1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mule.patches</groupId>
             <artifactId>SE-10165-4.1.4</artifactId>
             <version>1.0</version>
         </dependency>

--- a/bom/runtime-impl/pom.xml
+++ b/bom/runtime-impl/pom.xml
@@ -25,6 +25,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mule.patches</groupId>
+            <artifactId>SE-10007-4.1.4</artifactId>
+            <version>1.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-core</artifactId>
             <version>${mule.version}</version>

--- a/bom/runtime-impl/pom.xml
+++ b/bom/runtime-impl/pom.xml
@@ -20,6 +20,12 @@
     <dependencies>
         <dependency>
             <groupId>org.mule.patches</groupId>
+            <artifactId>SE-10165-4.1.4</artifactId>
+            <version>1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mule.patches</groupId>
             <artifactId>SE-10038-4.1.4</artifactId>
             <version>1.0</version>
         </dependency>

--- a/bom/runtime-impl/pom.xml
+++ b/bom/runtime-impl/pom.xml
@@ -20,6 +20,12 @@
     <dependencies>
         <dependency>
             <groupId>org.mule.patches</groupId>
+            <artifactId>SE-10038-4.1.4</artifactId>
+            <version>1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mule.patches</groupId>
             <artifactId>SE-9843-4.1.4</artifactId>
             <version>1.0</version>
         </dependency>

--- a/bom/runtime-impl/pom.xml
+++ b/bom/runtime-impl/pom.xml
@@ -19,6 +19,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.mule.patches</groupId>
+            <artifactId>SE-9843-4.1.4</artifactId>
+            <version>1.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-core</artifactId>
             <version>${mule.version}</version>


### PR DESCRIPTION
- Bringing patches from hfx-munit branch to its `support/*` counterpart