### PR TITLE
MULE-19025: removed dependency to log4j 1.2.17, since MULE-11458/MULE…

### DIFF
--- a/embedded/embedded-impl/pom.xml
+++ b/embedded/embedded-impl/pom.xml
@@ -39,12 +39,6 @@
             <artifactId>zip4j</artifactId>
             <version>2.1.2</version>
         </dependency>
-        <!-- TODO MULE-11458 - this dependency is not downloaded by maven because the zip extension -->
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
…-11383 is already done