### PR TITLE
Remove maven settings with only public repos

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,10 @@ def UPSTREAM_PROJECTS_LIST = [ "Mule-runtime/mule-integration-tests/support/4.2.
                                "Mule-runtime/mule-maven-client/1.4.0" ]
 
 Map pipelineParams = [ "upstreamProjects" : UPSTREAM_PROJECTS_LIST.join(','),
-                       "mavenSettingsXmlId" : "mule-runtime-maven-settings-MuleSettings",
+
+                       // Comment public setting to get org.mule.runtime:api-annotations:jar:1.1.0-20200709 from private
+                       // repo until it is released in a public repo
+                       // "mavenSettingsXmlId" : "mule-runtime-maven-settings-MuleSettings",
                        "projectType" : "Runtime" ]
 
 runtimeBuild(pipelineParams)

--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,7 @@
         <groupId>org.mule.runtime</groupId>
         <artifactId>mule</artifactId>
         <version>4.2.0-HF-SNAPSHOT</version>
+        <relativePath/>
     </parent>
     <groupId>org.mule.distributions</groupId>
     <artifactId>mule-distributions</artifactId>


### PR DESCRIPTION
This is to avoid failing trying to resolve org.mule.runtime:api-annotations:jar:1.1.0-20200709
which only is available in private repos ci-releases and releases-ee