### PR TITLE
EE-7990: Warning Illegal reflective access by EfficientReflectionHashCode with JDK 11 when starting Runtime (#813)

### DIFF
--- a/standalone/src/main/resources/conf/wrapper.conf
+++ b/standalone/src/main/resources/conf/wrapper.conf
@@ -184,7 +184,7 @@ wrapper.syslog.loglevel=NONE
 
 # Avoid warnings on reflective access
 # TODO: investigate a general solution for classloading modular dependencies (MULE-18391)
-set.JDK_JAVA_OPTIONS=--add-opens java.base/sun.net.www.protocol.file=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED  --add-opens java.desktop/java.beans=ALL-UNNAMED 
+set.JDK_JAVA_OPTIONS=--add-opens java.base/sun.net.www.protocol.file=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.desktop/java.beans=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED
 
 #********************************************************************
 # Wrapper Windows Properties


### PR DESCRIPTION
(cherry picked from commit 67f192907220a0b452c5a8d75824ba3b52aaebac)