### PR TITLE
W-12068009: ClassLoaderModelJsonSerializer must fail if the file has

### DIFF
--- a/standalone/assembly-allowlist.txt
+++ b/standalone/assembly-allowlist.txt
@@ -246,7 +246,7 @@
 /mule-standalone-${productVersion}/lib/opt/maven-settings-builder-3.3.9.jar
 /mule-standalone-${productVersion}/lib/opt/msg-simple-1.1.jar
 /mule-standalone-${productVersion}/lib/opt/api-annotations-1.4.0-+
-/mule-standalone-${productVersion}/lib/opt/mule-classloader-model-3.5.3.jar
+/mule-standalone-${productVersion}/lib/opt/mule-classloader-model-3.8.1-+
 /mule-standalone-${productVersion}/lib/opt/mule-maven-client-api-1.7.0-+
 /mule-standalone-${productVersion}/lib/opt/mule-maven-client-impl-1.7.0-+
 /mule-standalone-${productVersion}/lib/opt/mule-oauth-client-1.1.0-+


### PR DESCRIPTION
missing mandatory attributes