### PR TITLE
W-12761115: `xml-apis` shadows classes already present in Java 11/17 `java.xml` module

### DIFF
--- a/embedded/embedded-distribution/pom.xml
+++ b/embedded/embedded-distribution/pom.xml
@@ -24,7 +24,7 @@
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>unpack-dependencies</goal>
                         </goals>

--- a/standalone/assembly-allowlist.txt
+++ b/standalone/assembly-allowlist.txt
@@ -290,7 +290,6 @@
 /mule-standalone-${productVersion}/lib/opt/wagon-http-shared-3.4.2.jar
 /mule-standalone-${productVersion}/lib/opt/wagon-provider-api-3.4.2.jar
 /mule-standalone-${productVersion}/lib/opt/xerces2-xsd11-2.11.3-MULE-001.jar
-/mule-standalone-${productVersion}/lib/opt/xml-apis-1.4.01.jar
 /mule-standalone-${productVersion}/lib/opt/xmlbeans-3.1.0.jar
 /mule-standalone-${productVersion}/lib/opt/xmlschema-core-2.2.1.jar
 /mule-standalone-${productVersion}/lib/opt/yagi-1.0.44-8.jar
@@ -315,6 +314,9 @@
 /mule-standalone-${productVersion}/lib/opt/opentelemetry-semconv-1.20.1-alpha.jar
 /mule-standalone-${productVersion}/lib/opt/grpc-api-1.51.0.jar
 /mule-standalone-${productVersion}/lib/opt/grpc-context-1.51.0.jar
+# 3rd party libs to be loaded only when running with java 8
+/mule-standalone-${productVersion}/lib/opt/jdk-8
+/mule-standalone-${productVersion}/lib/opt/jdk-8/xml-apis-1.4.01.jar
 
 #
 # /lib/user

--- a/standalone/pom.xml
+++ b/standalone/pom.xml
@@ -240,6 +240,11 @@
         </dependency>
 
         <dependency>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.mule.distributions</groupId>
             <artifactId>mule-wrapper-additional-parameters-parser</artifactId>
             <version>${project.version}</version>

--- a/standalone/src/assembly/assembly.xml
+++ b/standalone/src/assembly/assembly.xml
@@ -413,7 +413,23 @@
 
                 <!-- Exclude parameter parsing -->
                 <exclude>org.mule.distributions:mule-wrapper-additional-parameters-parser</exclude>
+
+                <!-- Exclude JVM version specific libraries -->                
+                <exclude>xml-apis:xml-apis</exclude>
+
             </excludes>
+        </dependencySet>
+
+        <!-- 3rd-party libraries, jdk 8 specific -->
+        <dependencySet>
+            <outputDirectory>lib/opt/jdk-8</outputDirectory>
+            <useStrictFiltering>true</useStrictFiltering>
+            <includes>
+                <!-- Include JVM version specific libraries -->                
+
+                <!-- This has colliding packages with java.xml module (org.w3c.*) when running with java11+ -->
+                <include>xml-apis:xml-apis</include>
+            </includes>
         </dependencySet>
     </dependencySets>
 </assembly>


### PR DESCRIPTION
...effectively causing a split package error when starting up as module