### PR TITLE
W-12761115: `xml-apis` shadows classes already present in Java 11/17 `java.xml` module

### DIFF
--- a/embedded/embedded-impl-bom/pom.xml
+++ b/embedded/embedded-impl-bom/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <formatterConfigPath>../../formatter.xml</formatterConfigPath>
+        <xmlApisVersion>1.4.01</xmlApisVersion>
     </properties>
 
     <dependencies>
@@ -29,6 +30,11 @@
                     <artifactId>mule-runtime-impl-bom</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+            <version>${xmlApisVersion}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
* fix for embedded