### PR TITLE
W-12354025: Upgrade to snakeyaml 2.0 to address vulnerability in earlier versions

### DIFF
--- a/standalone/assembly-allowlist.txt
+++ b/standalone/assembly-allowlist.txt
@@ -277,7 +277,7 @@
 /mule-standalone-${productVersion}/lib/opt/rhino-1.7.12.jar
 /mule-standalone-${productVersion}/lib/opt/semver4j-3.1.0.jar
 /mule-standalone-${productVersion}/lib/opt/semantic-version-1.2.0.jar
-/mule-standalone-${productVersion}/lib/opt/snakeyaml-1.33.jar
+/mule-standalone-${productVersion}/lib/opt/snakeyaml-2.0.jar
 /mule-standalone-${productVersion}/lib/opt/spotbugs-annotations-4.7.3.jar
 /mule-standalone-${productVersion}/lib/opt/spring-aop-5.3.21.jar
 /mule-standalone-${productVersion}/lib/opt/spring-beans-5.3.21.jar


### PR DESCRIPTION
In October of 2022, a [critical flaw](https://nvd.nist.gov/vuln/detail/CVE-2022-1471) was found in the SnakeYAML package, which allowed an attacker to benefit from remote code execution by sending malicious YAML content and this content being deserialized by the constructor. Finally, in February 2023, the SnakeYAML 2.0 release was pushed that resolves this flaw, also referred to as [CVE-2022-1471](https://nvd.nist.gov/vuln/detail/CVE-2022-1471). Let’s break down how this version can help you resolve this critical flaw.