### PR TITLE
W-13137702: `slf4j` classes must be loaded from the same class loader from where its implementation is'

### DIFF
--- a/embedded/embedded-test/pom.xml
+++ b/embedded/embedded-test/pom.xml
@@ -81,6 +81,16 @@
             <version>2.11.3</version>
         </dependency>
 
+        <!--
+            TODO W-13205329 - remove, this is only needed because the requirement of org.slf4j in the boot layer messes
+             with the log4j implementation in the class loader created by mule-embedded-api, and the fix is to provide
+             it also at the boot layer level.
+        -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.mule.tests</groupId>
             <artifactId>mule-tests-allure</artifactId>

--- a/embedded/embedded-test/src/main/java/module-info.java
+++ b/embedded/embedded-test/src/main/java/module-info.java
@@ -21,6 +21,11 @@ module org.mule.distribution.embedded.test {
   requires org.slf4j;
   requires zip4j;
 
+  // TODO W-13205329 - remove, this is only needed because the requirement of org.slf4j in the boot layer messes with
+  //  the log4j implementation in the class loader created by mule-embedded-api, and the fix is to provide it also at
+  //  the boot layer level
+  requires org.apache.logging.log4j;
+
   exports org.mule.runtime.module.embedded to
       junit;
 


### PR DESCRIPTION
`mule-embedded-api` uses `slf4j` and users need to provide an implementation for it, for example `log4j`. Given `slf4j` will always be on the module-path when running embedded as a module, its implementation must be there too because Java's `ServiceLoader` will load service implementations from there, but the rest of the `log4j` classes will be loaded from the Runtime's container class loader.