### PR TITLE
W-13588773: Replace all javax jars bundled in the runtime with the jakarta equivalent

### DIFF
--- a/services-all/pom.xml
+++ b/services-all/pom.xml
@@ -181,6 +181,10 @@
                     <groupId>jakarta.xml.ws</groupId>
                     <artifactId>jakarta.xml.ws-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.sun.activation</groupId>
+                    <artifactId>jakarta.activation</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/standalone/assembly-allowlist.txt
+++ b/standalone/assembly-allowlist.txt
@@ -206,7 +206,6 @@
 /mule-standalone-${productVersion}/lib/opt/jackson-coreutils-1.9.jar
 /mule-standalone-${productVersion}/lib/opt/jackson-module-jsonSchema-2.15.0.jar
 /mule-standalone-${productVersion}/lib/opt/jakarta.activation-1.2.2.jar
-/mule-standalone-${productVersion}/lib/opt/jakarta.activation-api-1.2.2.jar
 /mule-standalone-${productVersion}/lib/opt/jakarta.annotation-api-1.3.5.jar
 /mule-standalone-${productVersion}/lib/opt/jakarta.jms-api-2.0.3.jar
 /mule-standalone-${productVersion}/lib/opt/jakarta.json-1.1.6.jar


### PR DESCRIPTION
* Addendum: remove activation-api and leave just activation (ref: https://github.com/jakartaee/jaf-api/issues/18)