### PR TITLE
W-12412013: Fixing sequence numbers for jvm-dependant wrapper additional parameters.

### DIFF
--- a/standalone/src/main/resources/conf/java11-plus/wrapper.jvmDependant.conf
+++ b/standalone/src/main/resources/conf/java11-plus/wrapper.jvmDependant.conf
@@ -7,5 +7,5 @@ wrapper.java.additional.<n2>=--add-modules=\
         com.fasterxml.jackson.core
 # TODO W-13718989: this reads to org.mule.boot should be declared in the reading module
 wrapper.java.additional.<n3>=--add-reads=org.mule.boot.tanuki=org.mule.boot
-wrapper.java.additional.<n3>=--add-exports=org.mule.boot/org.mule.runtime.module.reboot=ALL-UNNAMED
-wrapper.java.additional.<n4>=--add-opens=java.base/java.lang=org.mule.runtime.jpms.utils
+wrapper.java.additional.<n4>=--add-exports=org.mule.boot/org.mule.runtime.module.reboot=ALL-UNNAMED
+wrapper.java.additional.<n5>=--add-opens=java.base/java.lang=org.mule.runtime.jpms.utils


### PR DESCRIPTION
This is just a cosmetic fix, because those numbers are actually overwritten by the [wrapper additional parameters parser](https://github.com/mulesoft/mule-distributions/blob/29a7e4b7a428fe448c0337b5b6401f9e3a099fd7/mule-wrapper-additional-parameters-parser/src/main/java/org/mule/runtime/params/AdditionalJvmParameters.java#L268).