### PR TITLE
W-14445662: Dotnet connector build in windows instance fails since guava upgrade in 4.4.0-20230724 (#1216)

### DIFF
--- a/standalone/assembly-allowlist.txt
+++ b/standalone/assembly-allowlist.txt
@@ -213,7 +213,7 @@
 /mule-standalone-${productVersion}/lib/opt/failureaccess-1.0.1.jar
 /mule-standalone-${productVersion}/lib/opt/fastutil-8.5.11.jar
 /mule-standalone-${productVersion}/lib/opt/gson-2.8.9.jar
-/mule-standalone-${productVersion}/lib/opt/guava-32.1.1-jre.jar
+/mule-standalone-${productVersion}/lib/opt/guava-32.1.3-jre.jar
 /mule-standalone-${productVersion}/lib/opt/httpclient-4.5.13.jar
 /mule-standalone-${productVersion}/lib/opt/httpcore-4.4.16.jar
 /mule-standalone-${productVersion}/lib/opt/j2objc-annotations-2.8.jar


### PR DESCRIPTION
(cherry picked from commit ec64b3b496832c7fffd234b2ee494d0ee39b14a1)