### PR TITLE
W-14445662: Dotnet connector build in windows instance fails since guava upgrade in 4.4.0-20230724 (#1216)

### DIFF
--- a/standalone/assembly-allowlist.txt
+++ b/standalone/assembly-allowlist.txt
@@ -171,7 +171,7 @@
 /mule-standalone-${productVersion}/lib/opt/byte-buddy-1.10.7.jar
 /mule-standalone-${productVersion}/lib/opt/caffeine-2.8.0.jar
 /mule-standalone-${productVersion}/lib/opt/cglib-nodep-3.2.10.jar
-/mule-standalone-${productVersion}/lib/opt/checker-qual-3.33.0.jar
+/mule-standalone-${productVersion}/lib/opt/checker-qual-3.37.0.jar
 /mule-standalone-${productVersion}/lib/opt/commons-beanutils-1.9.4.jar
 /mule-standalone-${productVersion}/lib/opt/commons-codec-1.15.jar
 /mule-standalone-${productVersion}/lib/opt/commons-collections-3.2.2.jar

--- a/standalone/assembly-allowlist.txt
+++ b/standalone/assembly-allowlist.txt
@@ -189,7 +189,7 @@
 /mule-standalone-${productVersion}/lib/opt/fastutil-8.1.1.jar
 /mule-standalone-${productVersion}/lib/opt/geronimo-j2ee-connector_1.5_spec-2.0.0.jar
 /mule-standalone-${productVersion}/lib/opt/gson-2.8.9.jar
-/mule-standalone-${productVersion}/lib/opt/guava-32.1.1-jre.jar
+/mule-standalone-${productVersion}/lib/opt/guava-32.1.3-jre.jar
 /mule-standalone-${productVersion}/lib/opt/httpclient-4.5.13.jar
 /mule-standalone-${productVersion}/lib/opt/httpcore-4.4.13.jar
 /mule-standalone-${productVersion}/lib/opt/j2objc-annotations-2.8.jar

--- a/standalone/assembly-allowlist.txt
+++ b/standalone/assembly-allowlist.txt
@@ -184,7 +184,7 @@
 /mule-standalone-${productVersion}/lib/opt/config-1.3.1.jar
 /mule-standalone-${productVersion}/lib/opt/disruptor-1.2.10.jar
 /mule-standalone-${productVersion}/lib/opt/dom4j-2.1.3.jar
-/mule-standalone-${productVersion}/lib/opt/error_prone_annotations-2.18.0.jar
+/mule-standalone-${productVersion}/lib/opt/error_prone_annotations-2.21.1.jar
 /mule-standalone-${productVersion}/lib/opt/failureaccess-1.0.1.jar
 /mule-standalone-${productVersion}/lib/opt/fastutil-8.1.1.jar
 /mule-standalone-${productVersion}/lib/opt/geronimo-j2ee-connector_1.5_spec-2.0.0.jar


### PR DESCRIPTION
(cherry picked from commit ec64b3b496832c7fffd234b2ee494d0ee39b14a1)