### PR TITLE
W-12244913: XmlSdk + DietTooling: IllegalConnectionProviderModelDefinitionException: Connection Provider 'connection' does not provide a ConnectionProviderFactory

### DIFF
--- a/standalone/assembly-allowlist.txt
+++ b/standalone/assembly-allowlist.txt
@@ -203,6 +203,7 @@
 /mule-standalone-${productVersion}/lib/opt/checker-qual-3.+
 /mule-standalone-${productVersion}/lib/opt/commons-beanutils-1.+
 /mule-standalone-${productVersion}/lib/opt/commons-codec-1.+
+/mule-standalone-${productVersion}/lib/opt/commons-collections-3.+
 /mule-standalone-${productVersion}/lib/opt/commons-collections4-4.+
 /mule-standalone-${productVersion}/lib/opt/commons-io-2.+
 /mule-standalone-${productVersion}/lib/opt/commons-lang3-3.+


### PR DESCRIPTION
* commons-benutils uses commons-collections3