### PR TITLE
W-12244913: XmlSdk + DietTooling: IllegalConnectionProviderModelDefinitionException: Connection Provider 'connection' does not provide a ConnectionProviderFactory (#1265)

### DIFF
--- a/standalone/assembly-allowlist.txt
+++ b/standalone/assembly-allowlist.txt
@@ -201,6 +201,7 @@
 /mule-standalone-${productVersion}/lib/opt/checker-qual-3.33.0.jar
 /mule-standalone-${productVersion}/lib/opt/commons-beanutils-1.9.4.jar
 /mule-standalone-${productVersion}/lib/opt/commons-codec-1.15.jar
+/mule-standalone-${productVersion}/lib/opt/commons-collections-3.2.2.jar
 /mule-standalone-${productVersion}/lib/opt/commons-collections4-4.4.jar
 /mule-standalone-${productVersion}/lib/opt/commons-io-2.13.0.jar
 /mule-standalone-${productVersion}/lib/opt/commons-lang-2.6.jar


### PR DESCRIPTION
* commons-benutils uses commons-collections3